### PR TITLE
Lower default font size

### DIFF
--- a/term/src/main/res/values/defaults.xml
+++ b/term/src/main/res/values/defaults.xml
@@ -6,7 +6,7 @@
    <integer name="pref_orientation_default">0</integer>
    <string name="pref_cursorstyle_default" translatable="false">0</string>
    <string name="pref_cursorblink_default" translatable="false">0</string>
-   <string name="pref_fontsize_default" translatable="false">11</string>
+   <string name="pref_fontsize_default" translatable="false">10</string>
    <string name="pref_color_default" translatable="false">1</string>
    <bool name="pref_utf8_by_default_default">false</bool>
    <string name="pref_backaction_default" translatable="false">2</string>


### PR DESCRIPTION
Font size 11 doesn't exist in app and is too large for small screen sizes; e.g., hammerhead and bullhead
